### PR TITLE
JENKINS-25832: Launch multiple slaves in parallel

### DIFF
--- a/src/main/java/hudson/plugins/ec2/CloudHelper.java
+++ b/src/main/java/hudson/plugins/ec2/CloudHelper.java
@@ -1,0 +1,69 @@
+package hudson.plugins.ec2;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.Reservation;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckForNull;
+import java.util.Collections;
+import java.util.List;
+
+final class CloudHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudHelper.class);
+
+    static Instance getInstanceWithRetry(String instanceId, EC2Cloud cloud) throws AmazonClientException, InterruptedException {
+        // Sometimes even after a successful RunInstances, DescribeInstances
+        // returns an error for a few seconds. We do a few retries instead of
+        // failing instantly. See [JENKINS-15319].
+        for (int i = 0; i < 5; i++) {
+            try {
+                return getInstance(instanceId, cloud);
+            } catch (AmazonServiceException e) {
+                if (e.getErrorCode().equals("InvalidInstanceID.NotFound")) {
+                    // retry in 5 seconds.
+                    Thread.sleep(5000);
+                    continue;
+                }
+                throw e;
+            }
+        }
+        // Last time, throw on any error.
+        return getInstance(instanceId, cloud);
+    }
+
+    @CheckForNull
+    static Instance getInstance(String instanceId, EC2Cloud cloud) throws AmazonClientException {
+        if (StringUtils.isEmpty(instanceId) || cloud == null)
+            return null;
+
+        DescribeInstancesRequest request = new DescribeInstancesRequest();
+        request.setInstanceIds(Collections.<String> singletonList(instanceId));
+
+        List<Reservation> reservations = cloud.connect().describeInstances(request).getReservations();
+        if (reservations.size() != 1) {
+          String message = "Unexpected number of reservations reported by EC2 for instance id '" + instanceId + "', expected 1 result, found " + reservations + ".";
+          if (reservations.size() == 0) {
+            message += " Instance seems to be dead.";
+          }
+          LOGGER.info(message);
+          throw new AmazonClientException(message);
+        }
+        Reservation reservation = reservations.get(0);
+
+        List<Instance> instances = reservation.getInstances();
+        if (instances.size() != 1) {
+          String message = "Unexpected number of instances reported by EC2 for instance id '" + instanceId + "', expected 1 result, found " + instances + ".";
+          if (instances.size() == 0) {
+            message += " Instance seems to be dead.";
+          }
+          LOGGER.info(message);
+          throw new AmazonClientException(message);
+        }
+        return instances.get(0);
+    }
+}

--- a/src/main/java/hudson/plugins/ec2/EC2Cloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Cloud.java
@@ -43,11 +43,6 @@ import hudson.model.Node;
 import hudson.security.ACL;
 import hudson.slaves.Cloud;
 import hudson.slaves.NodeProvisioner.PlannedNode;
-import hudson.util.FormValidation;
-import hudson.util.HttpResponses;
-import hudson.util.ListBoxModel;
-import hudson.util.Secret;
-import hudson.util.StreamTaskListener;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -72,6 +67,7 @@ import java.util.Set;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -80,6 +76,11 @@ import java.util.logging.SimpleFormatter;
 import javax.servlet.ServletException;
 
 import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+import hudson.util.HttpResponses;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import hudson.util.StreamTaskListener;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
@@ -321,7 +322,7 @@ public abstract class EC2Cloud extends Cloud {
         StringWriter sw = new StringWriter();
         StreamTaskListener listener = new StreamTaskListener(sw);
         EC2AbstractSlave node = t.attach(id, listener);
-        Jenkins.getInstance().addNode(node);
+        Jenkins.getActiveInstance().addNode(node);
 
         rsp.sendRedirect2(req.getContextPath() + "/computer/" + node.getNodeName());
     }
@@ -337,12 +338,12 @@ public abstract class EC2Cloud extends Cloud {
         }
 
         try {
-            EC2AbstractSlave node = getNewOrExistingAvailableSlave(t, null, true);
-            if (node == null)
+            List<EC2AbstractSlave> nodes = getNewOrExistingAvailableSlave(t, 1, true);
+            if (nodes == null || nodes.isEmpty())
                 throw HttpResponses.error(SC_BAD_REQUEST, "Cloud or AMI instance cap would be exceeded for: " + template);
-            Jenkins.getInstance().addNode(node);
+            Jenkins.getActiveInstance().addNode(nodes.get(0));
 
-            return HttpResponses.redirectViaContextPath("/computer/" + node.getNodeName());
+            return HttpResponses.redirectViaContextPath("/computer/" + nodes.get(0).getNodeName());
         } catch (AmazonClientException e) {
             throw HttpResponses.error(SC_INTERNAL_SERVER_ERROR, e);
         }
@@ -514,14 +515,14 @@ public abstract class EC2Cloud extends Cloud {
      * Obtains a slave whose AMI matches the AMI of the given template, and that also has requiredLabel (if requiredLabel is non-null)
      * forceCreateNew specifies that the creation of a new slave is required. Otherwise, an existing matching slave may be re-used
      */
-    private synchronized EC2AbstractSlave getNewOrExistingAvailableSlave(SlaveTemplate template, Label requiredLabel, boolean forceCreateNew) {
+    private synchronized List<EC2AbstractSlave> getNewOrExistingAvailableSlave(SlaveTemplate t, int number, boolean forceCreateNew) {
         /*
          * Note this is synchronized between counting the instances and then allocating the node. Once the node is
          * allocated, we don't look at that instance as available for provisioning.
          */
-        int possibleSlavesCount = getPossibleNewSlavesCount(template);
+        int possibleSlavesCount = getPossibleNewSlavesCount(t);
         if (possibleSlavesCount < 0) {
-            LOGGER.log(Level.INFO, "Cannot provision - no capacity for instances: " + possibleSlavesCount);
+            LOGGER.log(Level.INFO, "{0}. Cannot provision - no capacity for instances: " + possibleSlavesCount, t);
             return null;
         }
 
@@ -531,67 +532,92 @@ public abstract class EC2Cloud extends Cloud {
                 provisionOptions = EnumSet.of(SlaveTemplate.ProvisionOptions.FORCE_CREATE);
             else if (possibleSlavesCount > 0)
                 provisionOptions = EnumSet.of(SlaveTemplate.ProvisionOptions.ALLOW_CREATE);
-            return template.provision(StreamTaskListener.fromStdout(), requiredLabel, provisionOptions);
+            return t.provision(number, provisionOptions);
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Exception during provisioning", e);
+            LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
             return null;
         }
     }
 
     @Override
-    public Collection<PlannedNode> provision(Label label, int excessWorkload) {
+    public Collection<PlannedNode> provision(final Label label, int excessWorkload) {
+        final SlaveTemplate t = getTemplate(label);
+        List<PlannedNode> plannedNodes = new ArrayList<>();
+
         try {
-            List<PlannedNode> r = new ArrayList<PlannedNode>();
-            final SlaveTemplate t = getTemplate(label);
-            LOGGER.log(Level.INFO, "Attempting to provision slave from template " + t + " needed by excess workload of " + excessWorkload + " units of label '" + label + "'");
-            if (label == null) {
-                LOGGER.log(Level.WARNING, String.format("Label is null - can't calculate how many executors slave will have. Using %s number of executors", t.getNumExecutors()));
+            LOGGER.log(Level.INFO, "{0}. Attempting to provision slave needed by excess workload of " + excessWorkload + " units", t);
+            int number = Math.max(Math.round(excessWorkload)/ t.getNumExecutors(), 1);
+            final List<EC2AbstractSlave> slaves = getNewOrExistingAvailableSlave(t, number, false);
+
+            if (slaves == null || slaves.isEmpty()) {
+                LOGGER.warning("Can't raise nodes for " + t);
+                return null;
             }
-            while (excessWorkload > 0) {
-                final EC2AbstractSlave slave = getNewOrExistingAvailableSlave(t, label, false);
-                // Returned null if a new node could not be created
-                if (slave == null)
-                    break;
-                LOGGER.log(Level.INFO, String.format("We have now %s computers", Jenkins.getInstance().getComputers().length));
-                Jenkins.getInstance().addNode(slave);
-                LOGGER.log(Level.INFO, String.format("Added node named: %s, We have now %s computers", slave.getNodeName(), Jenkins.getInstance().getComputers().length));
-                r.add(new PlannedNode(t.getDisplayName(), Computer.threadPoolForRemoting.submit(new Callable<Node>() {
 
-                    public Node call() throws Exception {
-                        long startTime = System.currentTimeMillis(); // fetch starting time
-                        while ((System.currentTimeMillis() - startTime) < slave.launchTimeout * 1000) {
-                            return tryToCallSlave(slave, t);
-                        }
-                        LOGGER.log(Level.WARNING, "Expected - Instance - failed to connect within launch timeout");
-                        return tryToCallSlave(slave, t);
-                    }
-                }), t.getNumExecutors()));
+            for (final EC2AbstractSlave slave : slaves) {
+                if (slave == null) {
+                    LOGGER.warning("Can't raise node for " + t);
+                    continue;
+                }
 
+                plannedNodes.add(createPlannedNode(t, slave));
                 excessWorkload -= t.getNumExecutors();
             }
-            LOGGER.log(Level.INFO, "Attempting provision - finished, excess workload: " + excessWorkload);
-            return r;
+
+            LOGGER.log(Level.INFO, "{0}. Attempting provision finished, excess workload: " + excessWorkload, t);
+            LOGGER.log(Level.INFO, "We have now {0} computers, waiting for {1} more",
+                    new Object[]{Jenkins.getActiveInstance().getComputers().length, plannedNodes.size()});
+            return plannedNodes;
         } catch (AmazonClientException e) {
-            LOGGER.log(Level.WARNING, "Exception during provisioning", e);
-            return Collections.emptyList();
-        } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Exception during provisioning", e);
+            LOGGER.log(Level.WARNING, t + ". Exception during provisioning", e);
             return Collections.emptyList();
         }
     }
 
-    private EC2AbstractSlave tryToCallSlave(EC2AbstractSlave slave, SlaveTemplate template) {
-    	try {
-            slave.toComputer().connect(false).get();
-        } catch (Exception e) {
-            if (template.spotConfig != null) {
-            	if(StringUtils.isNotEmpty(slave.getInstanceId()) && slave.isConnected) {
-            		LOGGER.log(Level.INFO, String.format("Instance id: %s for node: %s is connected now.", slave.getInstanceId(), slave.getNodeName()));
-            		return slave;
-            	}
-            }
-        }
-    	return slave;
+    private PlannedNode createPlannedNode(final SlaveTemplate t, final EC2AbstractSlave slave) {
+        return new PlannedNode(t.getDisplayName(),
+                Computer.threadPoolForRemoting.submit(new Callable<Node>() {
+                    public Node call() throws Exception {
+                        while (true) {
+                            String instanceId = slave.getInstanceId();
+                            if (slave instanceof EC2SpotSlave) {
+                                if (((EC2SpotSlave) slave).isSpotRequestDead()) {
+                                    LOGGER.log(Level.WARNING, "{0} Spot request died, can't do anything. Terminate provisioning", t);
+                                    return null;
+                                }
+
+                                // Spot Instance does not have instance id yet.
+                                if (StringUtils.isEmpty(instanceId)) {
+                                    Thread.sleep(5000);
+                                    continue;
+                                }
+                            }
+
+                            Instance instance = CloudHelper.getInstance(instanceId, slave.getCloud());
+                            if (instance == null) {
+                                LOGGER.log(Level.WARNING, "{0} Can't find instance with instance id `{1}` in cloud {2}. Terminate provisioning ",
+                                        new Object[]{t, instanceId, slave.cloudName});
+                                return null;
+                            }
+
+                            InstanceStateName state = InstanceStateName.fromValue(instance.getState().getName());
+                            if (state.equals(InstanceStateName.Running)) {
+                                long startTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - instance.getLaunchTime().getTime());
+                                LOGGER.log(Level.INFO, "{0} Node {1} moved to RUNNING state in {2} seconds and is ready to be connected by Jenkins",
+                                        new Object[]{t, slave.getNodeName(), startTime});
+                                return slave;
+                            }
+                            if (!state.equals(InstanceStateName.Pending)) {
+                                LOGGER.log(Level.WARNING, "{0}. Node {1} is neither pending, neither running, it's {2}. Terminate provisioning",
+                                        new Object[]{t, state, slave.getNodeName()});
+                                return null;
+                            }
+
+                            Thread.sleep(5000);
+                        }
+                    }
+                })
+                , t.getNumExecutors());
     }
 
     @Override
@@ -831,6 +857,7 @@ public abstract class EC2Cloud extends Cloud {
             if (exception != null)
                 message += " Exception: " + exception;
             LogRecord lr = new LogRecord(level, message);
+            lr.setLoggerName(LOGGER.getName());
             PrintStream printStream = listener.getLogger();
             printStream.print(sf.format(lr));
         }

--- a/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/EC2ComputerLauncher.java
@@ -28,21 +28,13 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.SlaveComputer;
 
 import java.io.IOException;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.model.Instance;
-import com.amazonaws.services.ec2.model.StartInstancesRequest;
-import com.amazonaws.services.ec2.model.StartInstancesResult;
 
 /**
- * {@link ComputerLauncher} for EC2 that waits for the instance to really come up before proceeding to the real
- * user-specified {@link ComputerLauncher}.
+ * {@link ComputerLauncher} for EC2 that wraps the real user-specified {@link ComputerLauncher}.
  *
  * @author Kohsuke Kawaguchi
  */
@@ -53,83 +45,8 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
     public void launch(SlaveComputer slaveComputer, TaskListener listener) {
         try {
             EC2Computer computer = (EC2Computer) slaveComputer;
-
-            while (true) {
-                String instanceId = computer.getInstanceId();
-                if (instanceId != null && !instanceId.equals("")) {
-                    break;
-                }
-                // Only spot slaves can have no instance id.
-                EC2SpotSlave ec2Slave = (EC2SpotSlave) computer.getNode();
-                if (ec2Slave.isSpotRequestDead()) {
-                    // Terminate launch
-                    return;
-                }
-                final String msg = "Node " + computer.getName() + "(SpotRequest " + computer.getSpotInstanceRequestId() +
-                    ") still requesting the instance, waiting 10s";
-                // report to system log and console
-                ((EC2Computer) slaveComputer).getCloud().log(LOGGER, Level.FINEST, listener, msg);
-                // check every 10 seconds if in spot request phase
-                Thread.sleep(10000);
-            }
-
-            final String baseMsg = "Node " + computer.getName() + "(" + computer.getInstanceId() + ")";
-            String msg;
-
-            OUTER: while (true) {
-                switch (computer.getState()) {
-                case PENDING:
-                    msg = baseMsg + " is still pending/launching, waiting 5s";
-                    break;
-                case STOPPING:
-                    msg = baseMsg + " is still stopping, waiting 5s";
-                    break;
-                case RUNNING:
-                    msg = baseMsg + " is ready";
-                    ((EC2Computer) slaveComputer).getCloud().log(LOGGER, Level.FINER, listener, msg);
-                    break OUTER;
-                case STOPPED:
-                    msg = baseMsg + " is stopped, sending start request";
-                    ((EC2Computer) slaveComputer).getCloud().log(LOGGER, Level.INFO, listener, msg);
-
-                    AmazonEC2 ec2 = computer.getCloud().connect();
-                    List<String> instances = new ArrayList<String>();
-                    instances.add(computer.getInstanceId());
-
-                    StartInstancesRequest siRequest = new StartInstancesRequest(instances);
-                    StartInstancesResult siResult = ec2.startInstances(siRequest);
-
-                    msg = baseMsg + ": sent start request, result: " + siResult;
-                    ((EC2Computer) slaveComputer).getCloud().log(LOGGER, Level.INFO, listener, msg);
-                    continue OUTER;
-                case SHUTTING_DOWN:
-                case TERMINATED:
-                    // abort
-                    msg = baseMsg + " is terminated or terminating, aborting launch";
-                    ((EC2Computer) slaveComputer).getCloud().log(LOGGER, Level.INFO, listener, msg);
-                    return;
-                default:
-                    msg = baseMsg + " is in an unknown state, retrying in 5s";
-                    break;
-                }
-
-                // report to system log and console
-                ((EC2Computer) slaveComputer).getCloud().log(LOGGER, Level.FINEST, listener, msg);
-                // check every 5 secs
-                Thread.sleep(5000);
-            }
-
-            launch(computer, listener, computer.describeInstance());
-        } catch (AmazonClientException e) {
-            e.printStackTrace(listener.error(e.getMessage()));
-            if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
-                LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
-                EC2AbstractSlave ec2AbstractSlave = (EC2AbstractSlave) slaveComputer.getNode();
-                if (ec2AbstractSlave != null) {
-                    ec2AbstractSlave.terminate();
-                }
-            }
-        } catch (IOException e) {
+            launchScript(computer, listener);
+        } catch (AmazonClientException | IOException e) {
             e.printStackTrace(listener.error(e.getMessage()));
             if (slaveComputer.getNode() instanceof  EC2AbstractSlave) {
                 LOGGER.log(Level.FINE, String.format("Terminating the ec2 agent %s due a problem launching or connecting to it", slaveComputer.getName()), e);
@@ -155,7 +72,7 @@ public abstract class EC2ComputerLauncher extends ComputerLauncher {
     /**
      * Stage 2 of the launch. Called after the EC2 instance comes up.
      */
-    protected abstract void launch(EC2Computer computer, TaskListener listener, Instance inst)
+    protected abstract void launchScript(EC2Computer computer, TaskListener listener)
             throws AmazonClientException, IOException, InterruptedException;
 
 }

--- a/src/main/java/hudson/plugins/ec2/EC2Step.java
+++ b/src/main/java/hudson/plugins/ec2/EC2Step.java
@@ -145,10 +145,13 @@ public class EC2Step extends Step {
                     EnumSet<SlaveTemplate.ProvisionOptions> opt = EnumSet.noneOf(SlaveTemplate.ProvisionOptions.class);
                     opt.add(universe);
 
-                    EC2AbstractSlave node = t.provision(TaskListener.NULL, null, opt);
-                    Jenkins.getInstance().addNode(node);
-                    Instance myInstance = EC2AbstractSlave.getInstance(node.getInstanceId(), node.getCloud());
-                    return myInstance;
+                    List<EC2AbstractSlave> instances = t.provision(1, opt);
+                    if (instances == null) {
+                        throw new IllegalArgumentException("Error in AWS Cloud. Please review AWS template defined in Jenkins configuration.");
+                    }
+
+                    EC2AbstractSlave slave = instances.get(0);
+                    return CloudHelper.getInstance(slave.getInstanceId(), (AmazonEC2Cloud) cl);
                 } else {
                     throw new IllegalArgumentException("Error in AWS Cloud. Please review AWS template defined in Jenkins configuration.");
                 }

--- a/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
+++ b/src/main/java/hudson/plugins/ec2/SlaveTemplate.java
@@ -391,6 +391,14 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
         return iamInstanceProfile;
     }
 
+    @Override
+    public String toString() {
+        return "SlaveTemplate{" +
+                "ami='" + ami + '\'' +
+                ", labels='" + labels + '\'' +
+                '}';
+    }
+
     public enum ProvisionOptions { ALLOW_CREATE, FORCE_CREATE }
 
     /**
@@ -398,259 +406,240 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
      *
      * @return always non-null. This needs to be then added to {@link Hudson#addNode(Node)}.
      */
-    public EC2AbstractSlave provision(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
+    public List<EC2AbstractSlave> provision(int number, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
         if (this.spotConfig != null) {
             if (provisionOptions.contains(ProvisionOptions.ALLOW_CREATE) || provisionOptions.contains(ProvisionOptions.FORCE_CREATE))
-                return provisionSpot(listener);
+                return provisionSpot(number);
             return null;
         }
-        return provisionOndemand(listener, requiredLabel, provisionOptions);
+        return provisionOndemand(number, provisionOptions);
     }
 
     /**
-     * Determines whether the AMI of the given instance matches the AMI of template and has the required label (if requiredLabel is non-null)
+     * Safely we can pickup only instance that is not known by Jenkins at all.
      */
-    private boolean checkInstance(PrintStream logger, Instance existingInstance, Label requiredLabel, EC2AbstractSlave[] returnNode) {
-        logProvision(logger, "checkInstance: " + existingInstance);
-        if (StringUtils.isNotBlank(getIamInstanceProfile())) {
-            if (existingInstance.getIamInstanceProfile() != null) {
-                if (!existingInstance.getIamInstanceProfile().getArn().equals(getIamInstanceProfile())) {
-                    logProvision(logger, " false - IAM Instance profile does not match");
-                    return false;
-                }
-                // Match, fall through
-            } else {
-                logProvision(logger, " false - Null IAM Instance profile");
+    private boolean checkInstance(Instance instance) {
+        for (EC2AbstractSlave node : NodeIterator.nodes(EC2AbstractSlave.class)) {
+            if (node.getInstanceId().equals(instance.getInstanceId())) {
+                logInstanceCheck(instance, ". false - found existing corresponding Jenkins slave: " + node.getInstanceId());
                 return false;
             }
         }
-
-        if (existingInstance.getState().getName().equalsIgnoreCase(InstanceStateName.Terminated.toString())
-                || existingInstance.getState().getName().equalsIgnoreCase(InstanceStateName.ShuttingDown.toString())) {
-            logProvision(logger, " false - Instance is terminated or shutting down");
-            return false;
-        }
-        // See if we know about this and it has capacity
-        for (EC2AbstractSlave node : NodeIterator.nodes(EC2AbstractSlave.class)) {
-            if (node.getInstanceId().equals(existingInstance.getInstanceId())) {
-                logProvision(logger, "Found existing corresponding Jenkins slave: " + node.getInstanceId());
-                if (!node.toComputer().isPartiallyIdle()) {
-                    logProvision(logger, " false - Node is not partially idle");
-                    return false;
-                }
-                // REMOVEME - this was added to force provision to work, but might not allow
-                // stopped instances to be found - need to investigate further
-                else if (false && node.toComputer().isOffline()) {
-                    logProvision(logger, " false - Node is offline");
-                    return false;
-                } else if (requiredLabel != null && !requiredLabel.matches(node.getAssignedLabels())) {
-                    logProvision(logger, " false - we need a Node having label " + requiredLabel);
-                    return false;
-                } else {
-                    logProvision(logger, " true - Node has capacity - can use it");
-                    returnNode[0] = node;
-                    return true;
-                }
-            }
-        }
-        logProvision(logger, " true - Instance has no node, but can be used");
+        logInstanceCheck(instance, " true - Instance is not connected to Jenkins");
         return true;
     }
 
-    private static void logProvision(PrintStream logger, String message) {
-        logger.println(message);
-        LOGGER.fine(message);
+    private void logInstanceCheck(Instance instance, String message) {
+        logProvisionInfo("checkInstance: " + instance.getInstanceId() + "." + message);
     }
 
-    private static void logProvisionInfo(PrintStream logger, String message) {
-        logger.println(message);
-        LOGGER.info(message);
+    private boolean isSameIamInstanceProfile(Instance instance) {
+        return StringUtils.isBlank(getIamInstanceProfile()) ||
+                (instance.getIamInstanceProfile() != null &&
+                        instance.getIamInstanceProfile().getArn().equals(getIamInstanceProfile()));
+
+    }
+
+    private boolean isTerminatingOrShuttindDown(String instanceStateName) {
+        return instanceStateName.equalsIgnoreCase(InstanceStateName.Terminated.toString())
+                || instanceStateName.equalsIgnoreCase(InstanceStateName.ShuttingDown.toString());
+    }
+
+    private void logProvisionInfo(String message) {
+        LOGGER.info(this + ". " + message);
     }
 
     /**
      * Provisions an On-demand EC2 slave by launching a new instance or starting a previously-stopped instance.
      */
-    private EC2AbstractSlave provisionOndemand(TaskListener listener, Label requiredLabel, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
-        PrintStream logger = listener.getLogger();
+    private List<EC2AbstractSlave> provisionOndemand(int number, EnumSet<ProvisionOptions> provisionOptions) throws AmazonClientException, IOException {
         AmazonEC2 ec2 = getParent().connect();
 
-        try {
-            logProvisionInfo(logger, "Considering launching " + ami + " for template " + description);
+        logProvisionInfo("Considering launching");
 
-            KeyPair keyPair = getKeyPair(ec2);
+        RunInstancesRequest riRequest = new RunInstancesRequest(ami, 1, number).withInstanceType(type);
+        riRequest.setEbsOptimized(ebsOptimized);
 
-            RunInstancesRequest riRequest = new RunInstancesRequest(ami, 1, 1);
-            InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
+        setupBlockDeviceMappings(riRequest.getBlockDeviceMappings());
 
-            riRequest.setEbsOptimized(ebsOptimized);
+        if(stopOnTerminate){
+            riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Stop);
+            logProvisionInfo("Setting Instance Initiated Shutdown Behavior : ShutdownBehavior.Stop");
+        }else{
+            riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Terminate);
+            logProvisionInfo("Setting Instance Initiated Shutdown Behavior : ShutdownBehavior.Terminate");
+        }
 
-            setupRootDevice(riRequest.getBlockDeviceMappings());
-            if (useEphemeralDevices) {
-                setupEphemeralDeviceMapping(riRequest.getBlockDeviceMappings());
-            } else {
-                setupCustomDeviceMapping(riRequest.getBlockDeviceMappings());
+        List<Filter> diFilters = new ArrayList<Filter>();
+        diFilters.add(new Filter("image-id").withValues(ami));
+        diFilters.add(new Filter("instance-type").withValues(type.toString()));
+
+        KeyPair keyPair = getKeyPair(ec2);
+        riRequest.setUserData(Base64.encodeBase64String(userData.getBytes(StandardCharsets.UTF_8)));
+        riRequest.setKeyName(keyPair.getKeyName());
+        diFilters.add(new Filter("key-name").withValues(keyPair.getKeyName()));
+
+
+        if (StringUtils.isNotBlank(getZone())) {
+            Placement placement = new Placement(getZone());
+            if (getUseDedicatedTenancy()) {
+                placement.setTenancy("dedicated");
             }
+            riRequest.setPlacement(placement);
+            diFilters.add(new Filter("availability-zone").withValues(getZone()));
+        }
 
-            if(stopOnTerminate){
-                riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Stop);
-                logProvisionInfo(logger, "Setting Instance Initiated Shutdown Behavior : ShutdownBehavior.Stop");
-            }else{
-                riRequest.setInstanceInitiatedShutdownBehavior(ShutdownBehavior.Terminate);
-                 logProvisionInfo(logger, "Setting Instance Initiated Shutdown Behavior : ShutdownBehavior.Terminate");
-            }
-
-            List<Filter> diFilters = new ArrayList<Filter>();
-            diFilters.add(new Filter("image-id").withValues(ami));
-
-            if (StringUtils.isNotBlank(getZone())) {
-                Placement placement = new Placement(getZone());
-                if (getUseDedicatedTenancy()) {
-                    placement.setTenancy("dedicated");
-                }
-                riRequest.setPlacement(placement);
-                diFilters.add(new Filter("availability-zone").withValues(getZone()));
-            }
-
-            if (StringUtils.isNotBlank(getSubnetId())) {
-                if (getAssociatePublicIp()) {
-                    net.setSubnetId(getSubnetId());
-                } else {
-                    riRequest.setSubnetId(getSubnetId());
-                }
-
-                diFilters.add(new Filter("subnet-id").withValues(getSubnetId()));
-
-                /*
-                 * If we have a subnet ID then we can only use VPC security groups
-                 */
-                if (!securityGroupSet.isEmpty()) {
-                    List<String> groupIds = getEc2SecurityGroups(ec2);
-
-                    if (!groupIds.isEmpty()) {
-                        if (getAssociatePublicIp()) {
-                            net.setGroups(groupIds);
-                        } else {
-                            riRequest.setSecurityGroupIds(groupIds);
-                        }
-
-                        diFilters.add(new Filter("instance.group-id").withValues(groupIds));
-                    }
-                }
-            } else {
-                /* No subnet: we can use standard security groups by name */
-                riRequest.setSecurityGroups(securityGroupSet);
-                if (!securityGroupSet.isEmpty()) {
-                    diFilters.add(new Filter("instance.group-name").withValues(securityGroupSet));
-                }
-            }
-
-            String userDataString = Base64.encodeBase64String(userData.getBytes(StandardCharsets.UTF_8));
-            riRequest.setUserData(userDataString);
-            riRequest.setKeyName(keyPair.getKeyName());
-            diFilters.add(new Filter("key-name").withValues(keyPair.getKeyName()));
-            riRequest.setInstanceType(type.toString());
-            diFilters.add(new Filter("instance-type").withValues(type.toString()));
-
+        InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
+        if (StringUtils.isNotBlank(getSubnetId())) {
             if (getAssociatePublicIp()) {
-                net.setAssociatePublicIpAddress(true);
-                net.setDeviceIndex(0);
-                riRequest.withNetworkInterfaces(net);
+                net.setSubnetId(getSubnetId());
+            } else {
+                riRequest.setSubnetId(getSubnetId());
             }
 
-            boolean hasCustomTypeTag = false;
-            HashSet<Tag> instTags = null;
-            if (tags != null && !tags.isEmpty()) {
-                instTags = new HashSet<Tag>();
-                for (EC2Tag t : tags) {
-                    instTags.add(new Tag(t.getName(), t.getValue()));
-                    diFilters.add(new Filter("tag:" + t.getName()).withValues(t.getValue()));
-                    if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
-                        hasCustomTypeTag = true;
+            diFilters.add(new Filter("subnet-id").withValues(getSubnetId()));
+
+            /*
+             * If we have a subnet ID then we can only use VPC security groups
+             */
+            if (!securityGroupSet.isEmpty()) {
+                List<String> groupIds = getEc2SecurityGroups(ec2);
+
+                if (!groupIds.isEmpty()) {
+                    if (getAssociatePublicIp()) {
+                        net.setGroups(groupIds);
+                    } else {
+                        riRequest.setSecurityGroupIds(groupIds);
                     }
+
+                    diFilters.add(new Filter("instance.group-id").withValues(groupIds));
                 }
             }
-            if (!hasCustomTypeTag) {
-                if (instTags == null) {
-                    instTags = new HashSet<Tag>();
-                }
-                // Append template description as well to identify slaves provisioned per template
-                instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(
-                        EC2Cloud.EC2_SLAVE_TYPE_DEMAND, description)));
+        } else {
+            /* No subnet: we can use standard security groups by name */
+            riRequest.setSecurityGroups(securityGroupSet);
+            if (!securityGroupSet.isEmpty()) {
+                diFilters.add(new Filter("instance.group-name").withValues(securityGroupSet));
             }
+        }
 
-            DescribeInstancesRequest diRequest = new DescribeInstancesRequest();
-            diRequest.setFilters(diFilters);
+        if (getAssociatePublicIp()) {
+            net.setAssociatePublicIpAddress(true);
+            net.setDeviceIndex(0);
+            riRequest.withNetworkInterfaces(net);
+        }
 
-            logProvision(logger, "Looking for existing instances with describe-instance: " + diRequest);
+        HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_DEMAND);
+        for (Tag tag : instTags) {
+            diFilters.add(new Filter("tag:" + tag.getKey()).withValues(tag.getValue()));
+        }
 
-            DescribeInstancesResult diResult = ec2.describeInstances(diRequest);
-            EC2AbstractSlave[] ec2Node = new EC2AbstractSlave[1];
-            Instance existingInstance = null;
-            if (!provisionOptions.contains(ProvisionOptions.FORCE_CREATE)) {
-                reservationLoop:
-                for (Reservation reservation : diResult.getReservations()) {
-                    for (Instance instance : reservation.getInstances()) {
-                        if (checkInstance(logger, instance, requiredLabel, ec2Node)) {
-                            existingInstance = instance;
-                            logProvision(logger, "Found existing instance: " + existingInstance + ((ec2Node[0] != null) ? (" node: " + ec2Node[0].getInstanceId()) : ""));
-                            break reservationLoop;
-                        }
-                    }
-                }
-            }
+        DescribeInstancesRequest diRequest = new DescribeInstancesRequest();
+        diRequest.setFilters(diFilters);
 
-            if (existingInstance == null) {
-                if (!provisionOptions.contains(ProvisionOptions.FORCE_CREATE) &&
-                    !provisionOptions.contains(ProvisionOptions.ALLOW_CREATE)) {
-                    logProvision(logger, "No existing instance found - but cannot create new instance");
-                    return null;
-                }
-                if (StringUtils.isNotBlank(getIamInstanceProfile())) {
-                    riRequest.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
-                }
+        logProvisionInfo("Looking for existing instances with describe-instance: " + diRequest);
 
-                if (instTags != null) {
-                    TagSpecification tagSpecification = new TagSpecification();
-                    tagSpecification.setResourceType(ResourceType.Instance);
-                    tagSpecification.setTags(instTags);
-                    Set<TagSpecification> tagSpecifications =  Collections.singleton(tagSpecification);
-                    riRequest.setTagSpecifications(tagSpecifications);
-                }
+        DescribeInstancesResult diResult = ec2.describeInstances(diRequest);
+        List<Instance> orphans = findOrphans(diResult, number);
 
-                // Have to create a new instance
-                Instance inst = ec2.runInstances(riRequest).getReservation().getInstances().get(0);
+        if (orphans.isEmpty() && !provisionOptions.contains(ProvisionOptions.FORCE_CREATE) &&
+                !provisionOptions.contains(ProvisionOptions.ALLOW_CREATE)) {
+            logProvisionInfo("No existing instance found - but cannot create new instance");
+            return null;
+        }
 
-                logProvisionInfo(logger, "No existing instance found - created new instance: " + inst);
-                return newOndemandSlave(inst);
-            }
+        wakeOrphansUp(ec2, orphans);
 
-            if (existingInstance.getState().getName().equalsIgnoreCase(InstanceStateName.Stopping.toString())
-                    || existingInstance.getState().getName().equalsIgnoreCase(InstanceStateName.Stopped.toString())) {
+        if (orphans.size() == number) {
+            return toSlaves(orphans);
+        }
 
-                List<String> instances = new ArrayList<String>();
-                instances.add(existingInstance.getInstanceId());
-                StartInstancesRequest siRequest = new StartInstancesRequest(instances);
-                StartInstancesResult siResult = ec2.startInstances(siRequest);
+        riRequest.setMaxCount(number - orphans.size());
 
-                logProvisionInfo(logger, "Found stopped instance - starting it: " + existingInstance + " result:" + siResult);
+        if (StringUtils.isNotBlank(getIamInstanceProfile())) {
+            riRequest.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
+        }
+
+        TagSpecification tagSpecification = new TagSpecification();
+        tagSpecification.setResourceType(ResourceType.Instance);
+        tagSpecification.setTags(instTags);
+        Set<TagSpecification> tagSpecifications =  Collections.singleton(tagSpecification);
+        riRequest.setTagSpecifications(tagSpecifications);
+
+        // Have to create a new instance
+        List<Instance> newInstances = ec2.runInstances(riRequest).getReservation().getInstances();
+
+        if (newInstances.isEmpty()) {
+            logProvisionInfo("No new instances were created");
+        }
+
+        newInstances.addAll(orphans);
+
+        return toSlaves(newInstances);
+    }
+
+    private void wakeOrphansUp(AmazonEC2 ec2, List<Instance> orphans) {
+        List<String> instances = new ArrayList<>();
+        for(Instance instance : orphans) {
+            if (instance.getState().getName().equalsIgnoreCase(InstanceStateName.Stopping.toString())
+                    || instance.getState().getName().equalsIgnoreCase(InstanceStateName.Stopped.toString())) {
+                logProvisionInfo("Found stopped instances - will start it: " + instance);
+                instances.add(instance.getInstanceId());
             } else {
                 // Should be pending or running at this point, just let it come up
-                logProvisionInfo(logger, "Found existing pending or running: " + existingInstance.getState().getName() + " instance: " + existingInstance);
+                logProvisionInfo("Found existing pending or running: " + instance.getState().getName() + " instance: " + instance);
             }
+        }
 
-            if (ec2Node[0] != null) {
-                logProvisionInfo(logger, "Using existing slave: " + ec2Node[0].getInstanceId());
-                return ec2Node[0];
+        if (!instances.isEmpty()) {
+            StartInstancesRequest siRequest = new StartInstancesRequest(instances);
+            StartInstancesResult siResult = ec2.startInstances(siRequest);
+
+            logProvisionInfo("Result of starting stopped instances:" + siResult);
+        }
+    }
+
+    private List<EC2AbstractSlave> toSlaves(List<Instance> newInstances) throws IOException {
+        try {
+            List<EC2AbstractSlave> slaves = new ArrayList<>(newInstances.size());
+            for (Instance instance : newInstances) {
+                slaves.add(newOndemandSlave(instance));
+                logProvisionInfo("Return instance: " + instance);
             }
-
-            // Existing slave not found
-            logProvision(logger, "Creating new slave for existing instance: " + existingInstance);
-            return newOndemandSlave(existingInstance);
-
+            return slaves;
         } catch (FormException e) {
             throw new AssertionError(e); // we should have discovered all
-                                        // configuration issues upfront
+            // configuration issues upfront
         }
+    }
+
+    private List<Instance> findOrphans(DescribeInstancesResult diResult, int number) {
+        List<Instance> orphans = new ArrayList<>();
+        int count = 0;
+        for (Reservation reservation : diResult.getReservations()) {
+            for (Instance instance : reservation.getInstances()) {
+                if (!isSameIamInstanceProfile(instance)) {
+                    logInstanceCheck(instance, ". false - IAM Instance profile does not match: " + instance.getIamInstanceProfile());
+                    continue;
+                }
+
+                if (isTerminatingOrShuttindDown(instance.getState().getName())) {
+                    logInstanceCheck(instance, ". false - Instance is terminated or shutting down");
+                    continue;
+                }
+
+                if (checkInstance(instance)) {
+                    logProvisionInfo("Found existing instance: " + instance);
+                    orphans.add(instance);
+                    count++;
+                }
+
+                if (count == number) {
+                    return orphans;
+                }
+            }
+        }
+        return orphans;
     }
 
     private void setupRootDevice(List<BlockDeviceMapping> deviceMappings) {
@@ -751,12 +740,10 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
     /**
      * Provision a new slave for an EC2 spot instance to call back to Jenkins
      */
-    private EC2AbstractSlave provisionSpot(TaskListener listener) throws AmazonClientException, IOException {
-        PrintStream logger = listener.getLogger();
+    private List<EC2AbstractSlave> provisionSpot(int number) throws AmazonClientException, IOException {
         AmazonEC2 ec2 = getParent().connect();
 
         try {
-            logger.println("Launching " + ami + " for template " + description);
             LOGGER.info("Launching " + ami + " for template " + description);
 
             KeyPair keyPair = getKeyPair(ec2);
@@ -765,16 +752,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
 
             // Validate spot bid before making the request
             if (getSpotMaxBidPrice() == null) {
-                // throw new FormException("Invalid Spot price specified: " +
-                // getSpotMaxBidPrice(), "spotMaxBidPrice");
                 throw new AmazonClientException("Invalid Spot price specified: " + getSpotMaxBidPrice());
             }
 
             spotRequest.setSpotPrice(getSpotMaxBidPrice());
-            spotRequest.setInstanceCount(1);
+            spotRequest.setInstanceCount(number);
 
             LaunchSpecification launchSpecification = new LaunchSpecification();
-            InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
 
             launchSpecification.setImageId(ami);
             launchSpecification.setInstanceType(type);
@@ -785,6 +769,7 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 launchSpecification.setPlacement(placement);
             }
 
+            InstanceNetworkInterfaceSpecification net = new InstanceNetworkInterfaceSpecification();
             if (StringUtils.isNotBlank(getSubnetId())) {
                 if (getAssociatePublicIp()) {
                     net.setSubnetId(getSubnetId());
@@ -832,35 +817,13 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 launchSpecification.withNetworkInterfaces(net);
             }
 
-            boolean hasCustomTypeTag = false;
-            HashSet<Tag> instTags = null;
-            if (tags != null && !tags.isEmpty()) {
-                instTags = new HashSet<Tag>();
-                for (EC2Tag t : tags) {
-                    instTags.add(new Tag(t.getName(), t.getValue()));
-                    if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
-                        hasCustomTypeTag = true;
-                    }
-                }
-            }
-            if (!hasCustomTypeTag) {
-                if (instTags == null) {
-                    instTags = new HashSet<Tag>();
-                }
-                instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(
-                        EC2Cloud.EC2_SLAVE_TYPE_SPOT, description)));
-            }
+            HashSet<Tag> instTags = buildTags(EC2Cloud.EC2_SLAVE_TYPE_SPOT);
 
             if (StringUtils.isNotBlank(getIamInstanceProfile())) {
                 launchSpecification.setIamInstanceProfile(new IamInstanceProfileSpecification().withArn(getIamInstanceProfile()));
             }
 
-            setupRootDevice(launchSpecification.getBlockDeviceMappings());
-            if (useEphemeralDevices) {
-                setupEphemeralDeviceMapping(launchSpecification.getBlockDeviceMappings());
-            } else {
-                setupCustomDeviceMapping(launchSpecification.getBlockDeviceMappings());
-            }
+            setupBlockDeviceMappings(launchSpecification.getBlockDeviceMappings());
 
             spotRequest.setLaunchSpecification(launchSpecification);
 
@@ -872,25 +835,25 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
                 throw new AmazonClientException("No spot instances found");
             }
 
-            SpotInstanceRequest spotInstReq = reqInstances.get(0);
-            if (spotInstReq == null) {
-                throw new AmazonClientException("Spot instance request is null");
-            }
-            String slaveName = spotInstReq.getSpotInstanceRequestId();
+            List<EC2AbstractSlave> slaves = new ArrayList<>(reqInstances.size());
+            for(SpotInstanceRequest spotInstReq : reqInstances) {
+                if (spotInstReq == null) {
+                    throw new AmazonClientException("Spot instance request is null");
+                }
+                String slaveName = spotInstReq.getSpotInstanceRequestId();
 
-            /* Now that we have our Spot request, we can set tags on it */
-            if (instTags != null) {
+                // Now that we have our Spot request, we can set tags on it
                 updateRemoteTags(ec2, instTags, "InvalidSpotInstanceRequestID.NotFound", spotInstReq.getSpotInstanceRequestId());
 
-                // That was a remote request - we should also update our local
-                // instance data.
+                // That was a remote request - we should also update our local instance data
                 spotInstReq.setTags(instTags);
+
+                LOGGER.info("Spot instance id in provision: " + spotInstReq.getSpotInstanceRequestId());
+
+                slaves.add(newSpotSlave(spotInstReq, slaveName));
             }
 
-            logger.println("Spot instance id in provision: " + spotInstReq.getSpotInstanceRequestId());
-            LOGGER.info("Spot instance id in provision: " + spotInstReq.getSpotInstanceRequestId());
-
-            return newSpotSlave(spotInstReq, slaveName);
+            return slaves;
 
         } catch (FormException e) {
             throw new AssertionError(); // we should have discovered all
@@ -899,6 +862,34 @@ public class SlaveTemplate implements Describable<SlaveTemplate> {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
+    }
+
+    private void setupBlockDeviceMappings(List<BlockDeviceMapping> blockDeviceMappings) {
+        setupRootDevice(blockDeviceMappings);
+        if (useEphemeralDevices) {
+            setupEphemeralDeviceMapping(blockDeviceMappings);
+        } else {
+            setupCustomDeviceMapping(blockDeviceMappings);
+        }
+    }
+
+    private HashSet<Tag> buildTags(String slaveType) {
+        boolean hasCustomTypeTag = false;
+        HashSet<Tag> instTags = new HashSet<Tag>();
+        if (tags != null && !tags.isEmpty()) {
+            instTags = new HashSet<Tag>();
+            for (EC2Tag t : tags) {
+                instTags.add(new Tag(t.getName(), t.getValue()));
+                if (StringUtils.equals(t.getName(), EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE)) {
+                    hasCustomTypeTag = true;
+                }
+            }
+        }
+        if (!hasCustomTypeTag) {
+            instTags.add(new Tag(EC2Tag.TAG_NAME_JENKINS_SLAVE_TYPE, EC2Cloud.getSlaveTypeTagValue(
+                    slaveType, description)));
+        }
+        return instTags;
     }
 
     protected EC2OndemandSlave newOndemandSlave(Instance inst) throws FormException, IOException {

--- a/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/win/EC2WindowsLauncher.java
@@ -27,7 +27,7 @@ public class EC2WindowsLauncher extends EC2ComputerLauncher {
     final long sleepBetweenAttemps = TimeUnit.SECONDS.toMillis(10);
 
     @Override
-    protected void launch(EC2Computer computer, TaskListener listener, Instance inst) throws IOException,
+    protected void launchScript(EC2Computer computer, TaskListener listener) throws IOException,
             AmazonClientException, InterruptedException {
         final PrintStream logger = listener.getLogger();
         final WinConnection connection = connectToWinRM(computer, logger);

--- a/src/test/java/hudson/plugins/ec2/EC2StepTest.java
+++ b/src/test/java/hudson/plugins/ec2/EC2StepTest.java
@@ -19,10 +19,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -57,14 +59,13 @@ public class EC2StepTest {
         r.addCloud(cl);
 
         when(instance.getNodeName()).thenReturn("nodeName");
+        List<EC2AbstractSlave> slaves = Collections.singletonList(instance);
+        when(st.provision(anyInt(),any(EnumSet.class))).thenReturn(slaves);
     }
 
 
     @Test
     public void bootInstance() throws Exception {
-
-        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
-
         WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
         boot.setDefinition(new CpsFlowDefinition(
                 " node('master') {\n" +
@@ -76,9 +77,6 @@ public class EC2StepTest {
 
     @Test
     public void boot_noCloud() throws Exception {
-
-        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
-
         WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
         boot.setDefinition(new CpsFlowDefinition(
                 " node('master') {\n" +
@@ -93,9 +91,7 @@ public class EC2StepTest {
 
     @Test
     public void boot_noTemplate() throws Exception {
-
         when(cl.getTemplate(anyString())).thenReturn(null);
-        when(st.provision(any(TaskListener.class),any(Label.class),any(EnumSet.class))).thenReturn(instance);
 
         WorkflowJob boot = r.jenkins.createProject(WorkflowJob.class, "EC2Test");
         boot.setDefinition(new CpsFlowDefinition(


### PR DESCRIPTION
This commit changes the behaviour of core functionality: raising new
nodes. It implements very simple algorithm:
- if NodeProvisioner requested X executors, start to raise
X/N nodes (N is number of executors on each node).
- if there is any orphant nodes (~non known by Jenkins at all), take
them in account (and start if it's neccessary)
- if there not enough orphant nodes - raise needed nodes in parallel
- give them back to NodeProvisioner in connected state
- nodes are connected by Jenkins itself: nodes are not connected
explicitly anymore (as it's needed by NodeProvisioner contract)
- EC2Cloud always returns instance in valid (RUNNING) state, it allows
to simplify logic of launcher

And reduce amount of duplicated code a little bit.